### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.7.1-alpine3.11
+
+LABEL maintainer Davide Polonio <poloniodavide@gmail.com>
+LABEL description "Simple CLI jira issue time tracker"
+
+COPY . /workdir/
+WORKDIR /workdir
+
+RUN apk add --no-cache git \
+  && gem build jirawatch.gemspec \
+  && gem install jirawatch-0.3.0.gem \
+  && rm -rf workdir
+
+ENTRYPOINT ["/usr/local/bundle/bin/jirawatch"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ gem install jirawatch-<gem-version>.gem
 
 You should now be good to go!
 
+### With Docker/Podman
+
+You can execute `jirawatch` without installing it on your machine! Jirawatch is available via Docker/Podman too, and it can be built from the repository with:
+```
+docker build -t <your username>/jirawatch
+docker run <your username>/jirawatch # enjoy the magic
+```
+
+Keep in mind that you need to setup persistence in order to store Jirawatch's configuration files. You can put in your `.bashrc` or `.zshrc` the following alias:
+```
+alias jirawatch="docker run --rm -it -v${HOME}/.jirawatch:/root/.jirawatch -v/etc/localtime:/etc/localtime:ro <your username>/jirawatch"
+```
+This will ensure persistence and will not modify your machine with additional packages ;)
+
 ## How to use
 As I stated before, this is not a complex tool! There are a few commands implemented as of right now:
 ```


### PR DESCRIPTION
* This allows to use jirawatch without installing the whole ruby stack