### PR TITLE
Implemented pause/resume timer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Tracking time is as simple as typing:
 ```
 jirawatch track ISSUE-873
 ```
-After that, jirawatch will start tracking your time and once you're done, a simple SIGINT (Ctrl + c) will stop tracking and save it to your Jira worklogs.
+After that, jirawatch will start tracking your time and, once you're done, you can press `Enter` or `Ctrl-x` to stop the time tracking and allow jirawatch to save it into the Jira worklogs of the related issue.
+If you want to make a pause, pressing the `space` bar will stop the time tracking and pressing it again will restart the timer.
 
 ## Installation
 There's no install script right now unfortunately (it will be coming though!).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tracking time is as simple as typing:
 jirawatch track ISSUE-873
 ```
 After that, jirawatch will start tracking your time and, once you're done, you can press `Ctrl-c` to stop the time tracking and allow jirawatch to save it into the Jira worklogs of the related issue.
-If you want to make a pause, pressing the `Ctrl-p` will stop the time tracking and pressing it again will restart the timer.
+If you need to stop tracking time, just press `Ctrl-p` and then press it again to resume.
 
 ## Installation
 There's no install script right now unfortunately (it will be coming though!).

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Tracking time is as simple as typing:
 ```
 jirawatch track ISSUE-873
 ```
-After that, jirawatch will start tracking your time and, once you're done, you can press `Enter` or `Ctrl-x` to stop the time tracking and allow jirawatch to save it into the Jira worklogs of the related issue.
-If you want to make a pause, pressing the `space` bar will stop the time tracking and pressing it again will restart the timer.
+After that, jirawatch will start tracking your time and, once you're done, you can press `Ctrl-c` to stop the time tracking and allow jirawatch to save it into the Jira worklogs of the related issue.
+If you want to make a pause, pressing the `Ctrl-p` will stop the time tracking and pressing it again will restart the timer.
 
 ## Installation
 There's no install script right now unfortunately (it will be coming though!).

--- a/lib/jirawatch/cli/login.rb
+++ b/lib/jirawatch/cli/login.rb
@@ -6,7 +6,7 @@ module Jirawatch
       include Jirawatch::Jira::Provisioning
 
       def call(*)
-        puts "Enter you Jira URL (eg. https://veryimportantcompany.atlassian.net)"
+        puts "Enter your Jira URL (eg. https://veryimportantcompany.atlassian.net)"
         site = STDIN.gets.chomp
         puts "Please enter your jira email/username: "
         name = STDIN.gets.chomp

--- a/lib/jirawatch/cli/track.rb
+++ b/lib/jirawatch/cli/track.rb
@@ -6,60 +6,57 @@ module Jirawatch
       include Jirawatch::CLI::AuthenticatedCommand
 
       argument :issue_key, required: true, desc: "Issue key that you want to track time for"
-      option :started_at, aliases: ["-t"], desc: "Specify when you started working on this issue with a HH:mm format"
+      option :time_started_at, aliases: ["-t"], desc: "Specify when you started working on this issue with a HH:mm format"
       option :worklog_message, aliases: ["-m"], desc: "Specify a work log message"
 
       def call(issue_key:, **options)
         @jira_client.Issue.find(issue_key) # Fails if issue doesn't exist
 
-        started_at = Time.parse(options.fetch(:started_at, Time.now.to_s))
-        # Time when the timer is paused
-        paused_at = 0
-        # Time when the timer is restarted
-        restarted_at = started_at
-        # Represents all the seconds of actual work spent (it does not count the time of the pauses)
+        time_started_at = Time.parse(options.fetch(:time_started_at, Time.now.to_s))
+        time_paused_at = 0
+        time_restarted_at = time_started_at
         partial_time_spent = 0
 
         puts "Logging time for #{issue_key}..."
-        puts started_at
-        puts "\n"
-        puts "Press space to pause/restart the timer"
-        puts "Press enter (or CTRL-X) when you have finished to track the time"
+        puts time_started_at
+        puts
+        puts "Press CTRL-P to pause/restart the timer"
+        puts "Press CTRL-C when you have finished to track the time"
 
         reader = TTY::Reader.new
-        reader.on(:keyspace) do
-          if paused_at == 0
-            paused_at = Time.now
-            partial_time_spent = (partial_time_spent + (paused_at - restarted_at)).floor
+        reader.on(:keyctrl_p) do
+          if time_paused_at == 0
+            time_paused_at = Time.now
+            partial_time_spent = partial_time_spent + (time_paused_at - time_restarted_at)
 
-            # Unit of time printed (the default is always plural)
-            time_unit = "minutes"
-            if (partial_time_spent / 60) == 1
-              time_unit = "minute"
-            end
+            time_unit =
+                if (partial_time_spent / 60).floor == 1
+                  "minute"
+                else
+                  "minutes"
+                end
 
-            puts "\n\n"
-            puts "===  PAUSE  ==="
-            puts "Time spent until now: #{(partial_time_spent / 60)} #{time_unit}"
-            puts "I hope you will come back soon :("
+            puts
+            puts "Timer has been paused with #{(partial_time_spent / 60).floor} #{time_unit} logged"
           else
-            paused_at = 0
-            restarted_at = Time.now
-            puts "\n\n"
-            puts "===  RESTART  ==="
-            puts "Now is the time to work hard!"
+            time_paused_at = 0
+            time_restarted_at = Time.now
+            puts
+            puts "Timer has been restarted"
           end
         end
 
-        reader.on(:keyenter, :keyctrl_x) do
-          total_time_spent = (partial_time_spent + (Time.now - restarted_at)).floor
+        loop do
+          reader.read_line("")
+        rescue Interrupt
+          total_time_spent = (partial_time_spent + (Time.now - time_restarted_at)).floor
 
           # Jira work logs have minute sensitivity thus API calls will fail with a time spent
           # which is less than 60 seconds
 
           fail! "Jira can't log less than 60 seconds of work" if total_time_spent < 60
 
-          worklog_file = Jirawatch.configuration.template_worklog_file % started_at.to_i
+          worklog_file = Jirawatch.configuration.template_worklog_file % time_started_at.to_i
           worklog_lines = []
 
           File.write worklog_file, options.fetch(:worklog_message) if options.key? :worklog_message
@@ -71,14 +68,14 @@ module Jirawatch
                   "# If you leave this empty, no work log will be saved"
           ) unless options.key? :worklog_message
 
-          File.readlines(Jirawatch.configuration.template_worklog_file % started_at.to_i).each do |line|
+          File.readlines(Jirawatch.configuration.template_worklog_file % time_started_at.to_i).each do |line|
             worklog_lines << line unless line.start_with?("#") or line.strip.empty?
           end
 
           @jira_client.Issue.find(issue_key).worklogs.build.save(
               {
                   timeSpentSeconds: total_time_spent,
-                  started: started_at.strftime("%Y-%m-%dT%H:%M:%S.%L%z"),
+                  started: time_started_at.strftime("%Y-%m-%dT%H:%M:%S.%L%z"),
                   comment: worklog_lines.join("\n")
               }
           ) unless worklog_lines.empty?
@@ -86,13 +83,6 @@ module Jirawatch
           puts "Worklog was empty, time was not tracked" if worklog_lines.empty?
 
           File.delete worklog_file
-          exit
-        end
-
-        loop do
-          reader.read_line("")
-        rescue Interrupt
-          # This is executed when the user presses CTRL-C, the only thing to do is to quit the program
           exit
         end
       end

--- a/lib/jirawatch/cli/track.rb
+++ b/lib/jirawatch/cli/track.rb
@@ -12,21 +12,52 @@ module Jirawatch
       def call(issue_key:, **options)
         @jira_client.Issue.find(issue_key) # Fails if issue doesn't exist
 
-        puts "Logging time for #{issue_key}..."
         started_at = Time.parse(options.fetch(:started_at, Time.now.to_s))
-        puts started_at
+        # Time when the timer is paused
+        paused_at = 0
+        # Time when the timer is restarted
+        restarted_at = started_at
+        # Represents all the seconds of actual work spent (it does not count the time of the pauses)
+        partial_time_spent = 0
 
-        begin
-          loop do
-            sleep 1
+        puts "Logging time for #{issue_key}..."
+        puts started_at
+        puts "\n"
+        puts "Press space to pause/restart the timer"
+        puts "Press enter (or CTRL-X) when you have finished to track the time"
+
+        reader = TTY::Reader.new
+        reader.on(:keyspace) do
+          if paused_at == 0
+            paused_at = Time.now
+            partial_time_spent = (partial_time_spent + (paused_at - restarted_at)).floor
+
+            # Unit of time printed (the default is always plural)
+            time_unit = "minutes"
+            if (partial_time_spent / 60) == 1
+              time_unit = "minute"
+            end
+
+            puts "\n\n"
+            puts "===  PAUSE  ==="
+            puts "Time spent until now: #{(partial_time_spent / 60)} #{time_unit}"
+            puts "I hope you will come back soon :("
+          else
+            paused_at = 0
+            restarted_at = Time.now
+            puts "\n\n"
+            puts "===  RESTART  ==="
+            puts "Now is the time to work hard!"
           end
-        rescue Interrupt
-          time_spent = (Time.now - started_at).floor
+        end
+
+        reader.on(:keyenter, :keyctrl_x) do
+          total_time_spent = (partial_time_spent + (Time.now - restarted_at)).floor
 
           # Jira work logs have minute sensitivity thus API calls will fail with a time spent
           # which is less than 60 seconds
 
-          fail! "Jira can't log less than 60 seconds of work" if time_spent < 60
+          fail! "Jira can't log less than 60 seconds of work" if total_time_spent < 60
 
           worklog_file = Jirawatch.configuration.template_worklog_file % started_at.to_i
           worklog_lines = []
@@ -35,7 +66,7 @@ module Jirawatch
           TTY::Editor.open(
               worklog_file,
               content: "\n" +
-                  "# You spent #{(time_spent / 60).floor} minutes on this issue\n" +
+                  "# You spent #{(total_time_spent / 60).floor} minutes on this issue\n" +
                   "# Write here your work log description\n" +
                   "# If you leave this empty, no work log will be saved"
           ) unless options.key? :worklog_message
@@ -46,7 +77,7 @@ module Jirawatch
 
           @jira_client.Issue.find(issue_key).worklogs.build.save(
               {
-                  timeSpentSeconds: time_spent,
+                  timeSpentSeconds: total_time_spent,
                   started: started_at.strftime("%Y-%m-%dT%H:%M:%S.%L%z"),
                   comment: worklog_lines.join("\n")
               }
@@ -55,6 +86,14 @@ module Jirawatch
           puts "Worklog was empty, time was not tracked" if worklog_lines.empty?
 
           File.delete worklog_file
+          exit
+        end
+
+        loop do
+          reader.read_line("")
+        rescue Interrupt
+          # This is executed when the user presses CTRL-C, the only thing to do is to quit the program
+          exit
         end
       end
     end

--- a/lib/jirawatch/cli/track.rb
+++ b/lib/jirawatch/cli/track.rb
@@ -6,76 +6,71 @@ module Jirawatch
       include Jirawatch::CLI::AuthenticatedCommand
 
       argument :issue_key, required: true, desc: "Issue key that you want to track time for"
-      option :time_started_at, aliases: ["-t"], desc: "Specify when you started working on this issue with a HH:mm format"
+      option :tracking_started_at, aliases: ["-t"], desc: "Specify when you started working on this issue with a HH:mm format"
       option :worklog_message, aliases: ["-m"], desc: "Specify a work log message"
 
       def call(issue_key:, **options)
         @jira_client.Issue.find(issue_key) # Fails if issue doesn't exist
 
-        time_started_at = Time.parse(options.fetch(:time_started_at, Time.now.to_s))
-        time_paused_at = 0
-        time_restarted_at = time_started_at
+        tracking_started_at = Time.parse(options.fetch(:tracking_started_at, Time.now.to_s))
+        tracking_paused_at = 0
+        tracking_restarted_at = tracking_started_at.to_i
         partial_time_spent = 0
 
         puts "Logging time for #{issue_key}..."
-        puts time_started_at
+        puts tracking_started_at
         puts
-        puts "Press CTRL-P to pause/restart the timer"
-        puts "Press CTRL-C when you have finished to track the time"
+        puts "Press CTRL-P to pause/restart tracking time"
+        puts "Press CTRL-C to stop tracking time"
 
         reader = TTY::Reader.new
         reader.on(:keyctrl_p) do
-          if time_paused_at == 0
-            time_paused_at = Time.now
-            partial_time_spent = partial_time_spent + (time_paused_at - time_restarted_at)
-
-            time_unit =
-                if (partial_time_spent / 60).floor == 1
-                  "minute"
-                else
-                  "minutes"
-                end
-
+          if tracking_paused_at == 0
+            tracking_paused_at = Time.now.to_i
+            partial_time_spent += tracking_paused_at - tracking_restarted_at
+            time_unit = partial_time_spent / 60 == 1 ? "minute" : "minutes"
             puts
-            puts "Timer has been paused with #{(partial_time_spent / 60).floor} #{time_unit} logged"
+            puts "Tracking has been paused with #{partial_time_spent / 60} #{time_unit} logged"
           else
-            time_paused_at = 0
-            time_restarted_at = Time.now
+            tracking_paused_at = 0
+            tracking_restarted_at = Time.now.to_i
             puts
-            puts "Timer has been restarted"
+            puts "Tracking has been restarted"
           end
         end
 
-        loop do
-          reader.read_line("")
+        begin
+          loop do
+            reader.read_line("")
+          end
         rescue Interrupt
-          total_time_spent = (partial_time_spent + (Time.now - time_restarted_at)).floor
+          total_time_spent = partial_time_spent + (Time.now.to_i - tracking_restarted_at)
 
           # Jira work logs have minute sensitivity thus API calls will fail with a time spent
           # which is less than 60 seconds
 
           fail! "Jira can't log less than 60 seconds of work" if total_time_spent < 60
 
-          worklog_file = Jirawatch.configuration.template_worklog_file % time_started_at.to_i
+          worklog_file = Jirawatch.configuration.template_worklog_file % tracking_started_at.to_i
           worklog_lines = []
 
           File.write worklog_file, options.fetch(:worklog_message) if options.key? :worklog_message
           TTY::Editor.open(
               worklog_file,
               content: "\n" +
-                  "# You spent #{(total_time_spent / 60).floor} minutes on this issue\n" +
+                  "# You spent #{total_time_spent / 60} minutes on this issue\n" +
                   "# Write here your work log description\n" +
                   "# If you leave this empty, no work log will be saved"
           ) unless options.key? :worklog_message
 
-          File.readlines(Jirawatch.configuration.template_worklog_file % time_started_at.to_i).each do |line|
+          File.readlines(Jirawatch.configuration.template_worklog_file % tracking_started_at.to_i).each do |line|
             worklog_lines << line unless line.start_with?("#") or line.strip.empty?
           end
 
           @jira_client.Issue.find(issue_key).worklogs.build.save(
               {
                   timeSpentSeconds: total_time_spent,
-                  started: time_started_at.strftime("%Y-%m-%dT%H:%M:%S.%L%z"),
+                  started: tracking_started_at.strftime("%Y-%m-%dT%H:%M:%S.%L%z"),
                   comment: worklog_lines.join("\n")
               }
           ) unless worklog_lines.empty?
@@ -83,7 +78,6 @@ module Jirawatch
           puts "Worklog was empty, time was not tracked" if worklog_lines.empty?
 
           File.delete worklog_file
-          exit
         end
       end
     end


### PR DESCRIPTION
The pause/resume feature works with `TTY::Reader`. It is mapped to the following keys:
 - `space` bar to pause/resume functionality
 - `Enter` or `Ctrl-x` to stop the timer and save the worklog

Using a SIGINT signal to stop the flow is not always a good idea and the `TTY::Reader` cannot be mapped to the `Ctrl-c` key so I decide to change the stop functionality with the `Ctrl-x` key.

- Updated Readme.md
- Fixed typo in the login.rb