### PR TITLE
Credential file with only user r/w permissions

### DIFF
--- a/lib/jirawatch/cli/login.rb
+++ b/lib/jirawatch/cli/login.rb
@@ -8,9 +8,9 @@ module Jirawatch
       def call(*)
         puts "Enter your Jira URL (eg. https://veryimportantcompany.atlassian.net)"
         site = STDIN.gets.chomp
-        puts "Please enter your jira email/username: "
+        puts "Enter your jira email/username: "
         name = STDIN.gets.chomp
-        puts "Please enter your API auth token: "
+        puts "Enter your API auth token: "
         token = STDIN.gets.chomp
 
         unless login name, token, site
@@ -18,8 +18,8 @@ module Jirawatch
           return
         end
 
-        puts "Login successful, credentials have been saved"
         save_credentials name, token, site
+        puts "Login successful, credentials have been saved"
       end
     end
   end

--- a/lib/jirawatch/jira/provisioning.rb
+++ b/lib/jirawatch/jira/provisioning.rb
@@ -29,8 +29,6 @@ module Jirawatch
           # Get some infos to check if login was successful
           client.ServerInfo.all.attrs["baseUrl"]
           return client
-        rescue JIRA::HTTPError => e
-          puts e.response.body
         rescue StandardError => e
           puts e.message
         end
@@ -42,6 +40,7 @@ module Jirawatch
         File.open(Jirawatch.configuration.login_file, "w") do |f|
           f.write ["username #{username}", "token #{token}", "site #{site}"].join "\n"
         end
+        File.chmod 0600, Jirawatch.configuration.login_file
       end
     end
   end


### PR DESCRIPTION
Now `access` credential file has only user r/w permissions. This was done to avoid eventual intruders to read and possibly steal user's Jira token and email