### PR TITLE
Update dependencies and their version

### DIFF
--- a/bin/jirawatch
+++ b/bin/jirawatch
@@ -1,5 +1,4 @@
 #!/usr/bin/env -S ruby -W0
-require 'bundler/setup'
 require 'dry/cli'
 Dir["#{__dir__}/../lib/jirawatch/**/*.rb"].sort.map { |file| File.expand_path(file) }.each do |file|
   require file

--- a/jirawatch.gemspec
+++ b/jirawatch.gemspec
@@ -6,14 +6,14 @@ Gem::Specification.new do |s|
   s.name        = 'jirawatch'
   s.version     = Jirawatch::Info::VERSION
   s.date        = '2020-02-27'
-  s.summary     = "Jira time tracker"
-  s.description = "A simple way to track jira issues time"
-  s.authors     = ["apontini"]
+  s.summary     = 'Jira time tracker'
+  s.description = 'A simple way to track jira issues time'
+  s.authors     = ['apontini']
   s.email       = 'alberto.pontini@gmail.com'
   s.files       = `git ls-files`.split($/)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  s.add_dependency "dry-cli"
-  s.add_dependency "jira-ruby"
-  s.add_dependency "tty-editor"
+  s.add_dependency 'dry-cli',  '~>0.6'
+  s.add_dependency 'jira-ruby', '~>2.1'
+  s.add_dependency 'tty-editor', '~>0.6'
 end


### PR DESCRIPTION
This tackles issue #15.
- Bundler dependency has been removed.
- Dependencies now have a pessimistic version set since it was a bad idea to not include a version in the first place